### PR TITLE
hotfixDev: get_document_owner_without_status_AUTHOR_SIGNED

### DIFF
--- a/backend/src/main/java/ru/caselab/edm/backend/repository/DocumentRepository.java
+++ b/backend/src/main/java/ru/caselab/edm/backend/repository/DocumentRepository.java
@@ -194,7 +194,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
                                                    order by dv1.createdAt DESC
              		                               LIMIT 1)
              		    AND (u.id = :userId)
-             		    AND (state IN ('AUTHOR_SIGNED', 'PENDING_AUTHOR_SIGN', 'PENDING_CONTRACTOR_SIGN')
+             		    AND (state IN ('PENDING_AUTHOR_SIGN', 'PENDING_CONTRACTOR_SIGN')
              		    OR ap.status IN('PUBLISHED_FOR_VOTING'))
              		    
             """, countQuery = """
@@ -209,7 +209,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
                                                    order by dv1.createdAt DESC
              		                               LIMIT 1)
              		    AND (u.id = :userId)
-             		    AND (state IN ('AUTHOR_SIGNED', 'PENDING_AUTHOR_SIGN', 'PENDING_CONTRACTOR_SIGN')
+             		    AND (state IN ('PENDING_AUTHOR_SIGN', 'PENDING_CONTRACTOR_SIGN')
              		    OR ap.status IN('PUBLISHED_FOR_VOTING'))
             """)
     Page<DocumentOutputAllDocumentsDTO> getAllDocumentWithNameAndStatusProjectionWhereUserOwnerBeforeSigner(UUID userId, Pageable pageable);


### PR DESCRIPTION
fixed receiving a document where the user is the author of the documents before signing - the status "AUTHOR_SIGNED" has been deleted